### PR TITLE
Pass effects when mapping over an array response

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -38,7 +38,7 @@ module.exports = function modify (response, effects) {
   })
 
   if (response instanceof Array) {
-    return response.map(modify, effects)
+    return response.map((response) => modify(response, effects)
   }
 
   return effects.reduce(function (flattened, effect) {

--- a/src/index.js
+++ b/src/index.js
@@ -38,7 +38,7 @@ module.exports = function modify (response, effects) {
   })
 
   if (response instanceof Array) {
-    return response.map(modify,effects)
+    return response.map(modify, effects)
   }
 
   return effects.reduce(function (flattened, effect) {

--- a/src/index.js
+++ b/src/index.js
@@ -38,7 +38,7 @@ module.exports = function modify (response, effects) {
   })
 
   if (response instanceof Array) {
-    return response.map(modify)
+    return response.map(modify,effects)
   }
 
   return effects.reduce(function (flattened, effect) {


### PR DESCRIPTION
If the response is an array, the effects currently get lost.